### PR TITLE
docs: fix Lance Spark connector option names and file paths

### DIFF
--- a/docs/src/user-guide/read.md
+++ b/docs/src/user-guide/read.md
@@ -4,29 +4,38 @@
 
 === "Python"
     ```python
+    # Method 1: Using path option
     df = (spark.read
         .format("lance")
-        .option("db", "/path/to/lance/database")
-        .option("dataset", "my_dataset")
+        .option("path", "/path/to/lance/database/my_dataset.lance")
         .load())
+    
+    # Method 2: Direct path (alternative)
+    df = spark.read.format("lance").load("/path/to/lance/database/my_dataset.lance")
     ```
 
 === "Scala"
     ```scala
+    // Method 1: Using path option
     val df = spark.read.
         format("lance").
-        option("db", "/path/to/lance/database").
-        option("dataset", "my_dataset").
+        option("path", "/path/to/lance/database/my_dataset.lance").
         load()
+    
+    // Method 2: Direct path (alternative)
+    val df = spark.read.format("lance").load("/path/to/lance/database/my_dataset.lance")
     ```
 
 === "Java"
     ```java
+    // Method 1: Using path option
     Dataset<Row> df = spark.read()
         .format("lance")
-        .option("db", "/path/to/lance/database")
-        .option("dataset", "my_dataset")
+        .option("path", "/path/to/lance/database/my_dataset.lance")
         .load();
+    
+    // Method 2: Direct path (alternative)
+    Dataset<Row> df = spark.read().format("lance").load("/path/to/lance/database/my_dataset.lance");
     ```
 
 ## Column Selection
@@ -38,8 +47,7 @@ You can specify which columns to read to improve performance:
     ```python
     df = (spark.read
         .format("lance")
-        .option("db", "/path/to/lance/database")
-        .option("dataset", "my_dataset")
+        .option("path", "/path/to/lance/database/my_dataset.lance")
         .load()
         .select("id", "name", "age"))
     ```
@@ -48,8 +56,7 @@ You can specify which columns to read to improve performance:
     ```scala
     val df = spark.read.
         format("lance").
-        option("db", "/path/to/lance/database").
-        option("dataset", "my_dataset").
+        option("path", "/path/to/lance/database/my_dataset.lance").
         load().
         select("id", "name", "age")
     ```
@@ -58,8 +65,7 @@ You can specify which columns to read to improve performance:
     ```java
     Dataset<Row> df = spark.read()
         .format("lance")
-        .option("db", "/path/to/lance/database")
-        .option("dataset", "my_dataset")
+        .option("path", "/path/to/lance/database/my_dataset.lance")
         .load()
         .select("id", "name", "age");
     ```
@@ -75,8 +81,7 @@ The filter is pushed down to reduce the amount of data read:
     
     filtered = (spark.read
         .format("lance")
-        .option("db", "/path/to/database")
-        .option("dataset", "users")
+        .option("path", "/path/to/database/users.lance")
         .load()
         .filter(
             col("age").between(25, 65) &
@@ -91,8 +96,7 @@ The filter is pushed down to reduce the amount of data read:
     
     val filtered = spark.read.
         format("lance").
-        option("db", "/path/to/database").
-        option("dataset", "users").
+        option("path", "/path/to/database/users.lance").
         load().
         filter(
             col("age").between(25, 65) &&
@@ -105,8 +109,7 @@ The filter is pushed down to reduce the amount of data read:
     ```java
     Dataset<Row> filtered = spark.read()
         .format("lance")
-        .option("db", "/path/to/database")
-        .option("dataset", "users")
+        .option("path", "/path/to/database/users.lance")
         .load()
         .filter("age BETWEEN 25 AND 65 AND department = 'Engineering' AND is_active = true");
     ```

--- a/docs/src/user-guide/write.md
+++ b/docs/src/user-guide/write.md
@@ -4,49 +4,44 @@
 
 === "Python"
     ```python
+    # Method 1: Using path option
     (df.write
         .format("lance")
-        .option("dataset_uri", "/path/to/lance/database/my_dataset")
+        .option("path", "/path/to/lance/database/my_dataset.lance")
         .save())
-    ```
-
-=== "Scala"
-    ```scala
-    df.write.
-        format("lance").
-        option("dataset_uri", "/path/to/lance/database/my_dataset").
-        save()
-    ```
-
-=== "Java"
-    ```java
-    df.write()
-        .format("lance")
-        .option("dataset_uri", "/path/to/lance/database/my_dataset")
-        .save();
-    ```
-
-Alternatively, you can specify the path directly in the `save()` method:
-
-=== "Python"
-    ```python
+    
+    # Method 2: Direct path (alternative)
     (df.write
         .format("lance")
-        .save("/path/to/lance/database/my_dataset"))
+        .save("/path/to/lance/database/my_dataset.lance"))
     ```
 
 === "Scala"
     ```scala
+    // Method 1: Using path option
     df.write.
         format("lance").
-        save("/path/to/lance/database/my_dataset")
+        option("path", "/path/to/lance/database/my_dataset.lance").
+        save()
+    
+    // Method 2: Direct path (alternative)
+    df.write.
+        format("lance").
+        save("/path/to/lance/database/my_dataset.lance")
     ```
 
 === "Java"
     ```java
+    // Method 1: Using path option
     df.write()
         .format("lance")
-        .save("/path/to/lance/database/my_dataset");
+        .option("path", "/path/to/lance/database/my_dataset.lance")
+        .save();
+    
+    // Method 2: Direct path (alternative)
+    df.write()
+        .format("lance")
+        .save("/path/to/lance/database/my_dataset.lance");
     ```
 
 ## Write Modes
@@ -57,46 +52,61 @@ By default, writing to a dataset at a specific path means creating the dataset:
 
 === "Python"
     ```python
-    # First write - succeeds
+    # First write - succeeds (Method 1: path option)
     (testData.write
         .format("lance")
-        .option("dataset_uri", "/path/to/database/users")
+        .option("path", "/path/to/database/users.lance")
         .save())
+    
+    # First write - succeeds (Method 2: direct path)
+    (testData.write
+        .format("lance")
+        .save("/path/to/database/users.lance"))
     
     # Second write - throws TableAlreadyExistsException
     (testData.write
         .format("lance")
-        .option("dataset_uri", "/path/to/database/users")
+        .option("path", "/path/to/database/users.lance")
         .save())
     ```
 
 === "Scala"
     ```scala
-    // First write - succeeds
+    // First write - succeeds (Method 1: path option)
     testData.write.
         format("lance").
-        option("dataset_uri", "/path/to/database/users").
+        option("path", "/path/to/database/users.lance").
         save()
+    
+    // First write - succeeds (Method 2: direct path)
+    testData.write.
+        format("lance").
+        save("/path/to/database/users.lance")
     
     // Second write - throws TableAlreadyExistsException
     testData.write.
         format("lance").
-        option("dataset_uri", "/path/to/database/users").
+        option("path", "/path/to/database/users.lance").
         save()
     ```
 
 === "Java"
     ```java
-    // First write - succeeds
+    // First write - succeeds (Method 1: path option)
     testData.write()
         .format("lance")
-        .option("dataset_uri", "/path/to/database/users")
+        .option("path", "/path/to/database/users.lance")
         .save();
+    
+    // First write - succeeds (Method 2: direct path)
+    testData.write()
+        .format("lance")
+        .save("/path/to/database/users.lance");
     
     // Second write - throws TableAlreadyExistsException
     testData.write()
         .format("lance")
-        .option("dataset_uri", "/path/to/database/users")
+        .option("path", "/path/to/database/users.lance")
         .save();
     ```
 
@@ -109,15 +119,21 @@ Add new data to an existing dataset:
     # Create initial dataset
     (testData.write
         .format("lance")
-        .option("dataset_uri", "/path/to/database/users")
+        .option("path", "/path/to/database/users.lance")
         .save())
     
-    # Append more data
+    # Append more data (Method 1: path option)
     (moreData.write
         .format("lance")
-        .option("dataset_uri", "/path/to/database/users")
+        .option("path", "/path/to/database/users.lance")
         .mode("append")
         .save())
+    
+    # Append more data (Method 2: direct path)
+    (moreData.write
+        .format("lance")
+        .mode("append")
+        .save("/path/to/database/users.lance"))
     ```
 
 === "Scala"
@@ -125,15 +141,21 @@ Add new data to an existing dataset:
     // Create initial dataset
     testData.write.
         format("lance").
-        option("dataset_uri", "/path/to/database/users").
+        option("path", "/path/to/database/users.lance").
         save()
     
-    // Append more data
+    // Append more data (Method 1: path option)
     moreData.write.
         format("lance").
-        option("dataset_uri", "/path/to/database/users").
+        option("path", "/path/to/database/users.lance").
         mode("append").
         save()
+    
+    // Append more data (Method 2: direct path)
+    moreData.write.
+        format("lance").
+        mode("append").
+        save("/path/to/database/users.lance")
     ```
 
 === "Java"
@@ -141,15 +163,21 @@ Add new data to an existing dataset:
     // Create initial dataset
     testData.write()
         .format("lance")
-        .option("dataset_uri", "/path/to/database/users")
+        .option("path", "/path/to/database/users.lance")
         .save();
     
-    // Append more data
+    // Append more data (Method 1: path option)
     moreData.write()
         .format("lance")
-        .option("dataset_uri", "/path/to/database/users")
+        .option("path", "/path/to/database/users.lance")
         .mode("append")
         .save();
+    
+    // Append more data (Method 2: direct path)
+    moreData.write()
+        .format("lance")
+        .mode("append")
+        .save("/path/to/database/users.lance");
     ```
 
 ### Overwrite
@@ -161,15 +189,21 @@ Replace the entire dataset with new data:
     # Create initial dataset
     (initialData.write
         .format("lance")
-        .option("dataset_uri", "/path/to/database/users")
+        .option("path", "/path/to/database/users.lance")
         .save())
     
-    # Completely replace the dataset
+    # Completely replace the dataset (Method 1: path option)
     (newData.write
         .format("lance")
-        .option("dataset_uri", "/path/to/database/users")
+        .option("path", "/path/to/database/users.lance")
         .mode("overwrite")
         .save())
+    
+    # Completely replace the dataset (Method 2: direct path)
+    (newData.write
+        .format("lance")
+        .mode("overwrite")
+        .save("/path/to/database/users.lance"))
     ```
 
 === "Scala"
@@ -177,15 +211,21 @@ Replace the entire dataset with new data:
     // Create initial dataset
     initialData.write.
         format("lance").
-        option("dataset_uri", "/path/to/database/users").
+        option("path", "/path/to/database/users.lance").
         save()
     
-    // Completely replace the dataset
+    // Completely replace the dataset (Method 1: path option)
     newData.write.
         format("lance").
-        option("dataset_uri", "/path/to/database/users").
+        option("path", "/path/to/database/users.lance").
         mode("overwrite").
         save()
+    
+    // Completely replace the dataset (Method 2: direct path)
+    newData.write.
+        format("lance").
+        mode("overwrite").
+        save("/path/to/database/users.lance")
     ```
 
 === "Java"
@@ -193,13 +233,19 @@ Replace the entire dataset with new data:
     // Create initial dataset
     initialData.write()
         .format("lance")
-        .option("dataset_uri", "/path/to/database/users")
+        .option("path", "/path/to/database/users.lance")
         .save();
     
-    // Completely replace the dataset
+    // Completely replace the dataset (Method 1: path option)
     newData.write()
         .format("lance")
-        .option("dataset_uri", "/path/to/database/users")
+        .option("path", "/path/to/database/users.lance")
         .mode("overwrite")
         .save();
+    
+    // Completely replace the dataset (Method 2: direct path)
+    newData.write()
+        .format("lance")
+        .mode("overwrite")
+        .save("/path/to/database/users.lance");
     ```


### PR DESCRIPTION
- Change incorrect 'db'/'dataset' options to 'path' in read.md
- Change incorrect 'dataset_uri' option to 'path' in write.md
- Add required '.lance' file extension to all path examples
- Document both option-based and direct path methods
- Fix examples for Python, Scala, and Java across all write modes

Fixes users getting "Missing required option path" errors when following documentation.

The error occurs in [`LanceConfig.java:55-58`](https://github.com/lancedb/lance-spark/blob/main/lance-spark-base_2.12/src/main/java/com/lancedb/lance/spark/LanceConfig.java#L55-L58):

```java
public static LanceConfig from(CaseInsensitiveStringMap options) {
  if (!options.containsKey(CONFIG_DATASET_URI)) {
    throw new IllegalArgumentException("Missing required option " + CONFIG_DATASET_URI);
  }
  return from(options, options.get(CONFIG_DATASET_URI));
}
```
**Note:** This fix makes documentation examples work by default with current implementation. Future code enhancements could potentially support the original `db`/`dataset` option pattern separately.
