### PR TITLE
fix: remove the restriction that path must have the suffix ".lance"

### DIFF
--- a/lance-spark-base_2.12/src/main/java/com/lancedb/lance/spark/LanceCatalog.java
+++ b/lance-spark-base_2.12/src/main/java/com/lancedb/lance/spark/LanceCatalog.java
@@ -53,14 +53,14 @@ public class LanceCatalog implements TableCatalog {
   public Table createTable(
       Identifier ident, StructType schema, Transform[] partitions, Map<String, String> properties)
       throws TableAlreadyExistsException, NoSuchNamespaceException {
+    LanceConfig config = LanceConfig.from(options, ident.name());
     try {
-      LanceConfig config = LanceConfig.from(options, ident.name());
       WriteParams params = SparkOptions.genWriteParamsFromConfig(config);
       LanceDatasetAdapter.createDataset(ident.name(), schema, params);
     } catch (IllegalArgumentException e) {
       throw new TableAlreadyExistsException(ident.name());
     }
-    return new LanceDataset(LanceConfig.from(options, ident.name()), schema);
+    return new LanceDataset(config, schema);
   }
 
   @Override

--- a/lance-spark-base_2.12/src/test/java/com/lancedb/lance/spark/LanceConfigTest.java
+++ b/lance-spark-base_2.12/src/test/java/com/lancedb/lance/spark/LanceConfigTest.java
@@ -26,7 +26,7 @@ public class LanceConfigTest {
   public void testLanceConfigFromCaseInsensitiveStringMap() {
     String dbPath = "file://path/to/db/";
     String datasetName = "testDatasetName";
-    String datasetUri = LanceConfig.getDatasetUri(dbPath, datasetName);
+    String datasetUri = TestUtils.getDatasetUri(dbPath, datasetName);
     CaseInsensitiveStringMap options =
         new CaseInsensitiveStringMap(
             new HashMap<String, String>() {
@@ -46,7 +46,7 @@ public class LanceConfigTest {
   public void testLanceConfigFromCaseInsensitiveStringMap2() {
     String dbPath = "s3://bucket/folder/";
     String datasetName = "testDatasetName";
-    String datasetUri = LanceConfig.getDatasetUri(dbPath, datasetName);
+    String datasetUri = TestUtils.getDatasetUri(dbPath, datasetName);
     CaseInsensitiveStringMap options =
         new CaseInsensitiveStringMap(
             new HashMap<String, String>() {
@@ -66,7 +66,7 @@ public class LanceConfigTest {
   public void testLanceConfigFromMap() {
     String dbPath = "file://path/to/db/";
     String datasetName = "testDatasetName";
-    String datasetUri = LanceConfig.getDatasetUri(dbPath, datasetName);
+    String datasetUri = TestUtils.getDatasetUri(dbPath, datasetName);
     Map<String, String> properties = new HashMap<>();
     properties.put(LanceConfig.CONFIG_DATASET_URI, datasetUri);
 
@@ -81,7 +81,7 @@ public class LanceConfigTest {
   public void testLanceConfigFromMap2() {
     String dbPath = "s3://bucket/folder/";
     String datasetName = "testDatasetName";
-    String datasetUri = LanceConfig.getDatasetUri(dbPath, datasetName);
+    String datasetUri = TestUtils.getDatasetUri(dbPath, datasetName);
     Map<String, String> properties = new HashMap<>();
     properties.put(LanceConfig.CONFIG_DATASET_URI, datasetUri);
 

--- a/lance-spark-base_2.12/src/test/java/com/lancedb/lance/spark/TestUtils.java
+++ b/lance-spark-base_2.12/src/test/java/com/lancedb/lance/spark/TestUtils.java
@@ -68,7 +68,7 @@ public class TestUtils {
       } else {
         throw new IllegalArgumentException("example_db not found in resources directory");
       }
-      datasetUri = LanceConfig.getDatasetUri(dbPath, datasetName);
+      datasetUri = getDatasetUri(dbPath, datasetName);
       lanceConfig = LanceConfig.from(datasetUri);
       inputPartition =
           new LanceInputPartition(
@@ -79,5 +79,16 @@ public class TestUtils {
               Optional.empty(),
               "test");
     }
+  }
+
+  public static String getDatasetUri(String dbPath, String datasetUri) {
+    StringBuilder sb = new StringBuilder().append(dbPath);
+    if (!dbPath.endsWith("/")) {
+      sb.append("/");
+    }
+    if (dbPath.equals(TestTable1Config.dbPath) && datasetUri.startsWith("test_dataset")) {
+      return sb.append(datasetUri).append(".lance").toString();
+    }
+    return sb.append(datasetUri).toString();
   }
 }

--- a/lance-spark-base_2.12/src/test/java/com/lancedb/lance/spark/read/BaseSparkConnectorLineItemTest.java
+++ b/lance-spark-base_2.12/src/test/java/com/lancedb/lance/spark/read/BaseSparkConnectorLineItemTest.java
@@ -15,6 +15,7 @@ package com.lancedb.lance.spark.read;
 
 import com.lancedb.lance.spark.LanceConfig;
 import com.lancedb.lance.spark.LanceDataSource;
+import com.lancedb.lance.spark.TestUtils;
 
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -55,8 +56,7 @@ public abstract class BaseSparkConnectorLineItemTest {
         spark
             .read()
             .format(LanceDataSource.name)
-            .option(
-                LanceConfig.CONFIG_DATASET_URI, LanceConfig.getDatasetUri(dbPath, "lineitem_10"))
+            .option(LanceConfig.CONFIG_DATASET_URI, TestUtils.getDatasetUri(dbPath, "lineitem_10"))
             .load();
     lanceData.createOrReplaceTempView("lance_dataset");
     parquetData = spark.read().parquet(parquetPath);

--- a/lance-spark-base_2.12/src/test/java/com/lancedb/lance/spark/read/BaseSparkConnectorReadTest.java
+++ b/lance-spark-base_2.12/src/test/java/com/lancedb/lance/spark/read/BaseSparkConnectorReadTest.java
@@ -51,7 +51,7 @@ public abstract class BaseSparkConnectorReadTest {
             .format(LanceDataSource.name)
             .option(
                 LanceConfig.CONFIG_DATASET_URI,
-                LanceConfig.getDatasetUri(dbPath, TestUtils.TestTable1Config.datasetName))
+                TestUtils.getDatasetUri(dbPath, TestUtils.TestTable1Config.datasetName))
             .load();
     data.createOrReplaceTempView("test_dataset1");
   }
@@ -169,14 +169,14 @@ public abstract class BaseSparkConnectorReadTest {
         spark
             .read()
             .format("lance")
-            .load(LanceConfig.getDatasetUri(dbPath, TestUtils.TestTable1Config.datasetName));
+            .load(TestUtils.getDatasetUri(dbPath, TestUtils.TestTable1Config.datasetName));
     validateData(df, TestUtils.TestTable1Config.expectedValues);
   }
 
   @Test
   public void supportBroadcastJoin() {
     Dataset<Row> df =
-        spark.read().format("lance").load(LanceConfig.getDatasetUri(dbPath, "test_dataset3"));
+        spark.read().format("lance").load(TestUtils.getDatasetUri(dbPath, "test_dataset3"));
     df.createOrReplaceTempView("test_dataset3");
     List<Row> desc =
         spark

--- a/lance-spark-base_2.12/src/test/java/com/lancedb/lance/spark/read/BaseSparkConnectorReadWithRowAddressTest.java
+++ b/lance-spark-base_2.12/src/test/java/com/lancedb/lance/spark/read/BaseSparkConnectorReadWithRowAddressTest.java
@@ -50,7 +50,7 @@ public abstract class BaseSparkConnectorReadWithRowAddressTest {
             .format(LanceDataSource.name)
             .option(
                 LanceConfig.CONFIG_DATASET_URI,
-                LanceConfig.getDatasetUri(dbPath, TestUtils.TestTable1Config.datasetName))
+                TestUtils.getDatasetUri(dbPath, TestUtils.TestTable1Config.datasetName))
             .load();
   }
 

--- a/lance-spark-base_2.12/src/test/java/com/lancedb/lance/spark/read/BaseSparkConnectorReadWithRowIdTest.java
+++ b/lance-spark-base_2.12/src/test/java/com/lancedb/lance/spark/read/BaseSparkConnectorReadWithRowIdTest.java
@@ -50,7 +50,7 @@ public abstract class BaseSparkConnectorReadWithRowIdTest {
             .format(LanceDataSource.name)
             .option(
                 LanceConfig.CONFIG_DATASET_URI,
-                LanceConfig.getDatasetUri(dbPath, TestUtils.TestTable1Config.datasetName))
+                TestUtils.getDatasetUri(dbPath, TestUtils.TestTable1Config.datasetName))
             .load();
   }
 

--- a/lance-spark-base_2.12/src/test/java/com/lancedb/lance/spark/write/BaseSparkConnectorWriteTest.java
+++ b/lance-spark-base_2.12/src/test/java/com/lancedb/lance/spark/write/BaseSparkConnectorWriteTest.java
@@ -15,6 +15,7 @@ package com.lancedb.lance.spark.write;
 
 import com.lancedb.lance.spark.LanceConfig;
 import com.lancedb.lance.spark.LanceDataSource;
+import com.lancedb.lance.spark.TestUtils;
 
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -91,8 +92,7 @@ public abstract class BaseSparkConnectorWriteTest {
         .write()
         .format(LanceDataSource.name)
         .option(
-            LanceConfig.CONFIG_DATASET_URI,
-            LanceConfig.getDatasetUri(dbPath.toString(), datasetName))
+            LanceConfig.CONFIG_DATASET_URI, TestUtils.getDatasetUri(dbPath.toString(), datasetName))
         .save();
 
     validateData(datasetName, 1);
@@ -105,8 +105,7 @@ public abstract class BaseSparkConnectorWriteTest {
         .write()
         .format(LanceDataSource.name)
         .option(
-            LanceConfig.CONFIG_DATASET_URI,
-            LanceConfig.getDatasetUri(dbPath.toString(), datasetName))
+            LanceConfig.CONFIG_DATASET_URI, TestUtils.getDatasetUri(dbPath.toString(), datasetName))
         .save();
 
     assertThrows(
@@ -117,7 +116,7 @@ public abstract class BaseSparkConnectorWriteTest {
               .format(LanceDataSource.name)
               .option(
                   LanceConfig.CONFIG_DATASET_URI,
-                  LanceConfig.getDatasetUri(dbPath.toString(), datasetName))
+                  TestUtils.getDatasetUri(dbPath.toString(), datasetName))
               .save();
         });
   }
@@ -129,15 +128,13 @@ public abstract class BaseSparkConnectorWriteTest {
         .write()
         .format(LanceDataSource.name)
         .option(
-            LanceConfig.CONFIG_DATASET_URI,
-            LanceConfig.getDatasetUri(dbPath.toString(), datasetName))
+            LanceConfig.CONFIG_DATASET_URI, TestUtils.getDatasetUri(dbPath.toString(), datasetName))
         .save();
     testData
         .write()
         .format(LanceDataSource.name)
         .option(
-            LanceConfig.CONFIG_DATASET_URI,
-            LanceConfig.getDatasetUri(dbPath.toString(), datasetName))
+            LanceConfig.CONFIG_DATASET_URI, TestUtils.getDatasetUri(dbPath.toString(), datasetName))
         .mode("append")
         .save();
     validateData(datasetName, 2);
@@ -154,7 +151,7 @@ public abstract class BaseSparkConnectorWriteTest {
               .format(LanceDataSource.name)
               .option(
                   LanceConfig.CONFIG_DATASET_URI,
-                  LanceConfig.getDatasetUri(dbPath.toString(), datasetName))
+                  TestUtils.getDatasetUri(dbPath.toString(), datasetName))
               .mode("append")
               .save();
         });
@@ -166,7 +163,7 @@ public abstract class BaseSparkConnectorWriteTest {
     testData
         .write()
         .format(LanceDataSource.name)
-        .save(LanceConfig.getDatasetUri(dbPath.toString(), datasetName));
+        .save(TestUtils.getDatasetUri(dbPath.toString(), datasetName));
 
     validateData(datasetName, 1);
   }
@@ -178,15 +175,13 @@ public abstract class BaseSparkConnectorWriteTest {
         .write()
         .format(LanceDataSource.name)
         .option(
-            LanceConfig.CONFIG_DATASET_URI,
-            LanceConfig.getDatasetUri(dbPath.toString(), datasetName))
+            LanceConfig.CONFIG_DATASET_URI, TestUtils.getDatasetUri(dbPath.toString(), datasetName))
         .save();
     testData
         .write()
         .format(LanceDataSource.name)
         .option(
-            LanceConfig.CONFIG_DATASET_URI,
-            LanceConfig.getDatasetUri(dbPath.toString(), datasetName))
+            LanceConfig.CONFIG_DATASET_URI, TestUtils.getDatasetUri(dbPath.toString(), datasetName))
         .mode("overwrite")
         .save();
 
@@ -200,23 +195,20 @@ public abstract class BaseSparkConnectorWriteTest {
         .write()
         .format(LanceDataSource.name)
         .option(
-            LanceConfig.CONFIG_DATASET_URI,
-            LanceConfig.getDatasetUri(dbPath.toString(), datasetName))
+            LanceConfig.CONFIG_DATASET_URI, TestUtils.getDatasetUri(dbPath.toString(), datasetName))
         .save();
     testData
         .write()
         .format(LanceDataSource.name)
         .option(
-            LanceConfig.CONFIG_DATASET_URI,
-            LanceConfig.getDatasetUri(dbPath.toString(), datasetName))
+            LanceConfig.CONFIG_DATASET_URI, TestUtils.getDatasetUri(dbPath.toString(), datasetName))
         .mode("overwrite")
         .save();
     testData
         .write()
         .format(LanceDataSource.name)
         .option(
-            LanceConfig.CONFIG_DATASET_URI,
-            LanceConfig.getDatasetUri(dbPath.toString(), datasetName))
+            LanceConfig.CONFIG_DATASET_URI, TestUtils.getDatasetUri(dbPath.toString(), datasetName))
         .mode("append")
         .save();
     validateData(datasetName, 2);
@@ -225,7 +217,7 @@ public abstract class BaseSparkConnectorWriteTest {
   @Test
   public void writeMultiFiles(TestInfo testInfo) {
     String datasetName = testInfo.getTestMethod().get().getName();
-    String filePath = LanceConfig.getDatasetUri(dbPath.toString(), datasetName);
+    String filePath = TestUtils.getDatasetUri(dbPath.toString(), datasetName);
     testData
         .write()
         .format(LanceDataSource.name)
@@ -240,7 +232,7 @@ public abstract class BaseSparkConnectorWriteTest {
   @Test
   public void writeEmptyTaskFiles(TestInfo testInfo) {
     String datasetName = testInfo.getTestMethod().get().getName();
-    String filePath = LanceConfig.getDatasetUri(dbPath.toString(), datasetName);
+    String filePath = TestUtils.getDatasetUri(dbPath.toString(), datasetName);
     testData
         .repartition(4)
         .write()
@@ -259,7 +251,7 @@ public abstract class BaseSparkConnectorWriteTest {
             .format("lance")
             .option(
                 LanceConfig.CONFIG_DATASET_URI,
-                LanceConfig.getDatasetUri(dbPath.toString(), datasetName))
+                TestUtils.getDatasetUri(dbPath.toString(), datasetName))
             .load();
 
     assertEquals(2 * iteration, data.count());
@@ -285,7 +277,7 @@ public abstract class BaseSparkConnectorWriteTest {
   @Test
   public void dropAndReplaceTable(TestInfo testInfo) {
     String datasetName = testInfo.getTestMethod().get().getName();
-    String path = LanceConfig.getDatasetUri(dbPath.toString(), datasetName);
+    String path = TestUtils.getDatasetUri(dbPath.toString(), datasetName);
     spark.sql("CREATE OR REPLACE TABLE lance.`" + path + "` AS SELECT * FROM tmp_view");
     spark.sql("CREATE OR REPLACE TABLE lance.`" + path + "` AS SELECT * FROM tmp_view");
     spark.sql("DROP TABLE lance.`" + path + "`");

--- a/lance-spark-base_2.12/src/test/java/com/lancedb/lance/spark/write/LanceBatchWriteTest.java
+++ b/lance-spark-base_2.12/src/test/java/com/lancedb/lance/spark/write/LanceBatchWriteTest.java
@@ -16,6 +16,7 @@ package com.lancedb.lance.spark.write;
 import com.lancedb.lance.Dataset;
 import com.lancedb.lance.WriteParams;
 import com.lancedb.lance.spark.LanceConfig;
+import com.lancedb.lance.spark.TestUtils;
 
 import org.apache.arrow.dataset.scanner.Scanner;
 import org.apache.arrow.memory.BufferAllocator;
@@ -48,7 +49,7 @@ public class LanceBatchWriteTest {
   @Test
   public void testLanceDataWriter(TestInfo testInfo) throws Exception {
     String datasetName = testInfo.getTestMethod().get().getName();
-    String datasetUri = LanceConfig.getDatasetUri(tempDir.toString(), datasetName);
+    String datasetUri = TestUtils.getDatasetUri(tempDir.toString(), datasetName);
     try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
       // Create lance dataset
       Field field = new Field("column1", FieldType.nullable(new ArrowType.Int(32, true)), null);


### PR DESCRIPTION
Spark Lance Connector requires that the ident of the table must have the suffix ".lance ", which is inconsistent with lance-core, so it is removed.