### PR TITLE
chore: bump lance-namespace dependency to 0.0.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <properties>
         <lance-spark.version>0.0.11</lance-spark.version>
         <lance.version>0.35.0</lance.version>
-        <lance-namespace.version>0.0.14</lance-namespace.version>
+        <lance-namespace.version>0.0.16</lance-namespace.version>
 
         <spark34.version>3.4.4</spark34.version>
         <spark35.version>3.5.5</spark35.version>


### PR DESCRIPTION
## Summary
- Bumped lance-namespace dependency from 0.0.14 to 0.0.16

## Test plan
- Verify builds pass with updated dependency
- Ensure all existing tests continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)